### PR TITLE
Added alternative env var string for Win32 so tests can pass.

### DIFF
--- a/t/complete_env_elem.t
+++ b/t/complete_env_elem.t
@@ -11,7 +11,9 @@ use Complete::Env qw(complete_env_elem);
 local $Complete::Common::OPT_FUZZY = 0;
 
 {
-    local $ENV{FOO} = 'foo:bar:baz';
+    local $ENV{FOO} = $^O eq q{MSWin32} ?
+        'foo;bar;baz' : 'foo:bar:baz';
+    
     test_complete(
         word      => 'ba',
         env       => 'FOO',

--- a/t/complete_path_env_elem.t
+++ b/t/complete_path_env_elem.t
@@ -11,7 +11,9 @@ use Complete::Env qw(complete_path_env_elem);
 local $Complete::Common::OPT_FUZZY = 0;
 
 {
-    local $ENV{PATH} = 'foo:bar:baz';
+    local $ENV{FOO} = $^O eq q{MSWin32} ?
+        'foo;bar;baz' : 'foo:bar:baz';
+    
     test_complete(
         word      => 'ba',
         result    => [qw(bar baz)],


### PR DESCRIPTION
Added alternative test string for the test ENV variables on Win32, which contains semi-colons instead of colons, which allows the complete_env_elem.t and complete_path_env_elem.t tests to pass.

This addresses [RT #120969](https://rt.cpan.org/Ticket/Display.html?id=120969)